### PR TITLE
Fix broken esm import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import { Client } from './Client';
 
-export default Client;
+export = Client;

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 'use strict';
-const guardian = require('../dist').default;
+const guardian = require('../dist');
 let api = new guardian('test_api_key', false);
 
 


### PR DESCRIPTION
Solves issue #27 

[As per the typescript docs](https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html#library-code-needs-special-considerations):

> Users will detect a misconfigured module smell if they have to access the .default property of a default import, and if they’re trying to write code that will run both in Node.js and a bundler, they might be stuck. Some third-party TypeScript transpilers expose options that change the way default exports are emitted to mitigate this difference, but they don’t produce their own declaration (.d.ts) files, so that creates a mismatch between the runtime behavior and the type checking, further confusing and frustrating users. Instead of using default exports, libraries that need to ship as CommonJS should use export = for modules that have a single main export, or named exports for modules that have multiple exports...

I have made this change, so now esm imports (import/export) and commonjs imports (require) will both work.

However, I had to change the import in the test file from ```require('../dist').default``` to ```require('../dist')```, so I guess that would break the import for existing users that are using ```.default```.